### PR TITLE
Fix `usleep` was not declared error on Arch Linux in test.cc

### DIFF
--- a/test.cc
+++ b/test.cc
@@ -12,6 +12,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 #include "joystick.hh"
+#include <unistd.h>
 
 int main(int argc, char** argv)
 {


### PR DESCRIPTION
I was getting this error on my Arch Linux box in test.cc:

```
test.cc:32:16: error: ‘usleep’ was not declared in this scope
     usleep(1000);
```

since `unistd.h` wasn't imported. This pull request imports `unistd.h`, fixing compilation on many Unix systems.
