### PR TITLE
Fixed trailing semi-colon

### DIFF
--- a/joystick.cc
+++ b/joystick.cc
@@ -63,4 +63,4 @@ bool Joystick::isFound()
 Joystick::~Joystick()
 {
   close(_fd);
-};
+}


### PR DESCRIPTION
Very small fix to avoid compiler warning.

Anyway, thanks for that really useful library.
