### PR TITLE
Add a new constructor which provides the option of opening the device in non blocking mode

### DIFF
--- a/joystick.cc
+++ b/joystick.cc
@@ -39,9 +39,17 @@ Joystick::Joystick(std::string devicePath)
   openPath(devicePath);
 }
 
-void Joystick::openPath(std::string devicePath)
+Joystick::Joystick(std::string devicePath, bool blocking)
 {
-  _fd = open(devicePath.c_str(), O_RDONLY | O_NONBLOCK);
+  openPath(devicePath, blocking);
+}
+
+void Joystick::openPath(std::string devicePath, bool blocking)
+{
+  if (blocking)
+    _fd = open(devicePath.c_str(), O_RDONLY);
+  else
+    _fd = open(devicePath.c_str(), O_RDONLY | O_NONBLOCK);
 }
 
 bool Joystick::sample(JoystickEvent* event)

--- a/joystick.hh
+++ b/joystick.hh
@@ -87,7 +87,7 @@ public:
 class Joystick
 {
 private:
-  void openPath(std::string devicePath);
+  void openPath(std::string devicePath, bool blocking=false);
   
   int _fd;
   
@@ -109,6 +109,12 @@ public:
    * Initialises an instance for the joystick device specified.
    */
   Joystick(std::string devicePath);
+
+  /**
+   * Initialises an instance for the joystick device specified and provide
+   * the option of blocking I/O.
+   */
+  Joystick(std::string devicePath, bool blocking);
  
   /**
    * Returns true if the joystick was found and may be used, otherwise false.


### PR DESCRIPTION
This modification adds a new constructor which provides the option of opening the device in non-blocking mode.  This is useful for applications that have the joystick interface running in its
own thread.  Backwards compatibility is maintained using an extra argument to openPath which
defaults to non-blocking mode.